### PR TITLE
fix(renovate): adjust config as private cant be extended

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,145 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>camunda/infra-renovate-config:default.json5"
-  ]
+    "config:recommended",
+    ":automergeDisabled",
+    ":semanticCommits",
+    ":dependencyDashboard",
+    ":enablePreCommit",
+  ],
+  schedule: ["every weekend"],
+  platformAutomerge: false,
+  prHourlyLimit: 6,
+  prConcurrentLimit: 20,
+  commitBodyTable: true,
+  separateMajorMinor: false,
+  prBodyNotes: [
+    "{{#if isMajor}}:warning: THIS IS A MAJOR VERSION UPDATE :warning:{{/if}}",
+    "Before merging, *always* check with the release notes if any other changes need to be done.",
+  ],
+  major: {
+    enabled: true,
+    addLabels: ["upgrade:major"],
+  },
+  minor: {
+    enabled: true,
+    addLabels: ["upgrade:minor"],
+  },
+  patch: {
+    enabled: true,
+    addLabels: ["upgrade:patch"],
+  },
+  vulnerabilityAlerts: {
+    addLabels: ["security"],
+    enabled: true
+  },
+  packageRules: [
+    // limit the PR creation for the Renovate pre-commit hook (it's released very frequently)
+    {
+      matchPackageNames: ["renovatebot/pre-commit-hooks"],
+      matchUpdateTypes: ["patch"],
+      enabled: false,
+    },
+    {
+      matchPackageNames: ["renovatebot/pre-commit-hooks"],
+      schedule: ["on Saturday"],
+    },
+    {
+      matchManagers: ["github-actions"],
+      addLabels: ["group:github-actions", "component:ci"],
+    },
+    // Terraform AWS modules
+    {
+      matchDatasources: ["terraform-module"],
+      matchPackagePatterns: ["terraform-aws-modules.*"],
+      addLabels: ["group:terraform"],
+      groupName: "Terraform AWS modules",
+      schedule: [
+        "every 2 weeks on Saturday and Sunday",
+      ],
+    },
+    // Terraform major provider updates
+    {
+      matchDatasources: ["terraform-provider"],
+      addLabels: ["group:terraform"],
+      schedule: [
+        "every 2 weeks on Saturday and Sunday",
+      ]
+    },
+    // Terraform patch provider updates
+    {
+      matchUpdateTypes: ["patch"],
+      matchDatasources: ["terraform-provider"],
+      addLabels: ["group:terraform", "automerge"],
+      groupName: "Terraform providers",
+      automerge: true,
+      schedule: [
+        "every 2 weeks on Saturday and Sunday",
+      ]
+    },
+    // GitHub Actions
+    {
+      matchUpdateTypes: ["minor", "patch"],
+      matchManagers: ["github-actions"],
+      addLabels: ["automerge"],
+      automerge: true,
+    },
+    // Patches
+    // Those are tested packages, and we know that they follow the semver convention,
+    // but it's fine to have candidate packages to test before move them to minor section.
+    {
+      matchUpdateTypes: ["patch"],
+      matchPackagePatterns: [
+        "aquasecurity/tfsec",
+        "pre-commit",
+        "^terraform$",
+        "terraform-aws-modules/.+",
+        "terraform-docs",
+        "terraform-linters/tflint",
+      ],
+      addLabels: ["automerge"],
+      automerge: true,
+    },
+    // Minor versions
+    // Those are tested packages, and we know that they follow the semver convention,
+    // but it's fine to have candidate packages to test before move them to minor section.
+    {
+      matchUpdateTypes: ["minor"],
+      matchPackagePatterns: [
+        "pre-commit",
+        "terraform-docs",
+        "terraform-linters/tflint",
+      ],
+      addLabels: ["automerge"],
+      automerge: true,
+    },
+    // Create PRs and automerge mentioned components afterward
+    // Those are tested packages
+    {
+      matchUpdateTypes: ["major"],
+      matchPackagePatterns: [
+        "pre-commit/.+",
+      ],
+      addLabels: ["automerge"],
+      automerge: true,
+    },
+    {
+      matchUpdateTypes: ["major", "minor", "patch"],
+      matchManagers: ["pre-commit"],
+      groupName: "pre-commit hooks",
+      addLabels: ["automerge"],
+      automerge: true
+    },
+    // For known GitHub repositories that use GitHub tags/releases of format
+    // "v1.2.3" and where the asdf plugin ignores the "v" prefix, we also tell
+    // Renovate to ignore it via extractVersion when updating .tool-version file
+    {
+      matchFileNames: ["**/.tool-versions", "**/*.tf"],
+      matchPackageNames: [
+        "hashicorp/terraform",
+        "pre-commit/pre-commit",
+      ],
+      extractVersion: "^v(?<version>.*)$",
+    },
+  ],
 }


### PR DESCRIPTION
Since a public repo can't extend a private config, the useful bits applicable to this repo have been copied over.

Generally, tooling automerge is likely fine.
Patches of Terraform and providers as well. With some test pipelines we can also extend it to minor.

The automerge sections can be extended in the future.

The asdf bits aren't needed as none of them require custom parsing but I think it's quite useful for the future.