### PR TITLE
fix: version tf lint

### DIFF
--- a/.lint/terraform_docs/.terraform-docs.yml
+++ b/.lint/terraform_docs/.terraform-docs.yml
@@ -1,7 +1,7 @@
 ---
 # Configuration documentation https://terraform-docs.io/user-guide/configuration/
 formatter: "markdown table"  # Required
-version: "0.17"
+version: "" # version is managed by asdf
 
 header-from: main.tf
 footer-from: ""


### PR DESCRIPTION
This PR fixes the hardcoded version of tfdoc that breaks when it's not synced with the one defined in asdf.
In order to fix that, I propose that we let asdf be the single source of trust.

Related PR https://github.com/camunda/camunda-tf-eks-module/pull/61