### PR TITLE
fix(cloud-nuke): cleanup not cleaning up resources

### DIFF
--- a/.github/workflows/nightly_cleanup.yml
+++ b/.github/workflows/nightly_cleanup.yml
@@ -61,6 +61,8 @@ jobs:
           --force \
           --older-than ${{ env.CLEANUP_OLDER_THAN }} \
           --exclude-resource-type ec2_dhcp_option \
+          --exclude-resource-type ec2-keypairs \
+          --exclude-resource-type s3 \
           --exclude-resource-type cloudtrail || true
 
       # Following will delete global resources and things that cloud-nuke does not support
@@ -79,4 +81,6 @@ jobs:
           --force \
           --older-than ${{ env.CLEANUP_OLDER_THAN }} \
           --exclude-resource-type ec2_dhcp_option \
-          --exclude-resource-type cloudtrail
+          --exclude-resource-type cloudtrail \
+          --exclude-resource-type ec2-keypairs \
+          --exclude-resource-type s3


### PR DESCRIPTION
- reversed "newer than" to "older than" otherwise, resources were not deleted
- excluded s3 and keypairs 

related to https://github.com/camunda/team-infrastructure-experience/issues/261