### PR TITLE
chore(eks/tf): add oidc output to allow additional external irsa mapp…

### DIFF
--- a/modules/eks-cluster/README.md
+++ b/modules/eks-cluster/README.md
@@ -79,6 +79,7 @@ module "eks_cluster" {
 | <a name="output_default_security_group_id"></a> [default\_security\_group\_id](#output\_default\_security\_group\_id) | The ID of the security group created by default on VPC creation |
 | <a name="output_ebs_cs_arn"></a> [ebs\_cs\_arn](#output\_ebs\_cs\_arn) | Amazon Resource Name of the ebs-csi IAM role used for IAM Roles to Service Accounts mappings |
 | <a name="output_external_dns_arn"></a> [external\_dns\_arn](#output\_external\_dns\_arn) | Amazon Resource Name of the external-dns IAM role used for IAM Roles to Service Accounts mappings |
+| <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | Amazon Resource Name of the OIDC provider for the EKS cluster. Allows to add additional IRSA mappings |
 | <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | The IDs of the private route tables associated with this VPC |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | Private subnet IDs |
 | <a name="output_private_vpc_cidr_blocks"></a> [private\_vpc\_cidr\_blocks](#output\_private\_vpc\_cidr\_blocks) | Private VPC CIDR blocks |

--- a/modules/eks-cluster/outputs.tf
+++ b/modules/eks-cluster/outputs.tf
@@ -66,6 +66,11 @@ output "external_dns_arn" {
   description = "Amazon Resource Name of the external-dns IAM role used for IAM Roles to Service Accounts mappings"
 }
 
+output "oidc_provider_arn" {
+  value       = module.eks.oidc_provider_arn
+  description = "Amazon Resource Name of the OIDC provider for the EKS cluster. Allows to add additional IRSA mappings"
+}
+
 ################################################################################
 # VPC
 ################################################################################


### PR DESCRIPTION
…ings

Minor addition to expose the oidc provider arn as output.
This will allow external users to create IRSA mappings that are not covered by default, e.g. cluster autoscaler.