### PR TITLE
chore(postgres): update default cert to rds-ca-rsa2048-g1

### DIFF
--- a/modules/aurora/README.md
+++ b/modules/aurora/README.md
@@ -48,7 +48,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | If true, minor engine upgrades will be applied automatically to the DB instance during the maintenance window | `bool` | `true` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | Array of availability zones to use for the Aurora cluster | `list(string)` | <pre>[<br>  "eu-central-1a",<br>  "eu-central-1b",<br>  "eu-central-1c"<br>]</pre> | no |
-| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-2019"` | no |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB instance | `string` | `"rds-ca-rsa2048-g1"` | no |
 | <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | The CIDR blocks to allow acces from and to. | `list(string)` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster, also used to prefix dependent resources. Format: /[[:lower:][:digit:]-]/ | `any` | n/a | yes |
 | <a name="input_default_database_name"></a> [default\_database\_name](#input\_default\_database\_name) | The name for the automatically created database on cluster creation. | `string` | `"camunda"` | no |

--- a/modules/aurora/variables.tf
+++ b/modules/aurora/variables.tf
@@ -81,7 +81,7 @@ variable "iam_auth_enabled" {
 }
 
 variable "ca_cert_identifier" {
-  default     = "rds-ca-2019"
+  default     = "rds-ca-rsa2048-g1"
   type        = string
   description = "Specifies the identifier of the CA certificate for the DB instance"
 }

--- a/test/src/custom_eks_rds_test.go
+++ b/test/src/custom_eks_rds_test.go
@@ -304,7 +304,7 @@ func (suite *CustomEKSRDSTestSuite) TestCustomEKSAndRDS() {
 	suite.Assert().Equal("db.t3.medium", *describeDBInstanceOutput.DBInstances[0].DBInstanceClass)
 	suite.Assert().Equal(true, *describeDBInstanceOutput.DBInstances[0].AutoMinorVersionUpgrade)
 	suite.Assert().Equal("aurora-postgresql", *describeDBInstanceOutput.DBInstances[0].Engine)
-	suite.Assert().Equal("rds-ca-2019", *describeDBInstanceOutput.DBInstances[0].CertificateDetails.CAIdentifier)
+	suite.Assert().Equal("rds-ca-rsa2048-g1", *describeDBInstanceOutput.DBInstances[0].CertificateDetails.CAIdentifier)
 	suite.Assert().Equal(varsConfigAurora["vpc_id"].(string), *describeDBInstanceOutput.DBInstances[0].DBSubnetGroup.VpcId)
 	suite.Assert().Contains(*describeDBInstanceOutput.DBInstances[0].AvailabilityZone, suite.region)
 


### PR DESCRIPTION
the proposed cert is the default in AWS and expires in 2061.
The old one has expired and is not supported anymore.