### PR TITLE
Infex #461 Update opensearch instance type in AWS examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module "opensearch_domain" {
   vpc_id          = module.eks_cluster.vpc_id
   cidr_blocks      = concat(module.eks_cluster.private_vpc_cidr_blocks, module.eks_cluster.public_vpc_cidr_blocks)
 
-  instance_type   = "t3.small.search"
+  instance_type   = "m7i.large.search"
   instance_count  = 3
   ebs_volume_size = 100
 

--- a/examples/camunda-8.6-irsa/opensearch.tf
+++ b/examples/camunda-8.6-irsa/opensearch.tf
@@ -19,7 +19,7 @@ module "opensearch_domain" {
   domain_name    = local.opensearch_domain_name
   engine_version = "2.15"
 
-  instance_type   = "t3.medium.search"
+  instance_type   = "m7i.large.search"
   instance_count  = 3 # one instance per AZ
   ebs_volume_size = 50
 

--- a/examples/camunda-8.6/opensearch.tf
+++ b/examples/camunda-8.6/opensearch.tf
@@ -7,7 +7,7 @@ module "opensearch_domain" {
   domain_name    = local.opensearch_domain_name
   engine_version = "2.15"
 
-  instance_type = "t3.medium.search"
+  instance_type = "m7i.large.search"
 
   instance_count  = 3 # one instance per AZ
   ebs_volume_size = 50

--- a/examples/camunda-8.7-irsa/opensearch.tf
+++ b/examples/camunda-8.7-irsa/opensearch.tf
@@ -19,7 +19,7 @@ module "opensearch_domain" {
   domain_name    = local.opensearch_domain_name
   engine_version = "2.15"
 
-  instance_type   = "t3.medium.search"
+  instance_type   = "m7i.large.search"
   instance_count  = 3 # one instance per AZ
   ebs_volume_size = 50
 

--- a/examples/camunda-8.7/opensearch.tf
+++ b/examples/camunda-8.7/opensearch.tf
@@ -7,7 +7,7 @@ module "opensearch_domain" {
   domain_name    = local.opensearch_domain_name
   engine_version = "2.15"
 
-  instance_type = "t3.medium.search"
+  instance_type = "m7i.large.search"
 
   instance_count  = 3 # one instance per AZ
   ebs_volume_size = 50

--- a/modules/opensearch/README.md
+++ b/modules/opensearch/README.md
@@ -16,7 +16,7 @@ module "opensearch_domain" {
   vpc_id          = module.eks_cluster.vpc_id
   cidr_blocks      = concat(module.eks_cluster.private_vpc_cidr_blocks, module.eks_cluster.public_vpc_cidr_blocks)
 
-  instance_type   = "t3.small.search"
+  instance_type   = "m7i.large.search"
   instance_count  = 3
   ebs_volume_size = 100
 
@@ -97,7 +97,7 @@ No modules.
 | <a name="input_create_timeout"></a> [create\_timeout](#input\_create\_timeout) | How much time to wait for the creation before timing out. | `string` | `"2h"` | no |
 | <a name="input_dedicated_master_count"></a> [dedicated\_master\_count](#input\_dedicated\_master\_count) | Number of dedicated master nodes in the cluster. | `number` | `3` | no |
 | <a name="input_dedicated_master_enabled"></a> [dedicated\_master\_enabled](#input\_dedicated\_master\_enabled) | Indicates whether dedicated master nodes are enabled for the cluster. | `bool` | `true` | no |
-| <a name="input_dedicated_master_type"></a> [dedicated\_master\_type](#input\_dedicated\_master\_type) | Instance type of the dedicated master nodes in the cluster. | `string` | `"m4.large.search"` | no |
+| <a name="input_dedicated_master_type"></a> [dedicated\_master\_type](#input\_dedicated\_master\_type) | Instance type of the dedicated master nodes in the cluster. | `string` | `"m5.large.search"` | no |
 | <a name="input_domain_endpoint_options"></a> [domain\_endpoint\_options](#input\_domain\_endpoint\_options) | Configuration block for domain endpoint HTTP(S) related options | `any` | <pre>{<br/>  "enforce_https": true,<br/>  "tls_security_policy": "Policy-Min-TLS-1-2-2019-07"<br/>}</pre> | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Name of the domain. | `string` | n/a | yes |
 | <a name="input_ebs_enabled"></a> [ebs\_enabled](#input\_ebs\_enabled) | Whether EBS volumes are attached to data nodes in the domain. | `bool` | `true` | no |

--- a/modules/opensearch/variables.tf
+++ b/modules/opensearch/variables.tf
@@ -60,7 +60,7 @@ variable "dedicated_master_enabled" {
 variable "dedicated_master_type" {
   type        = string
   description = "Instance type of the dedicated master nodes in the cluster."
-  default     = "m4.large.search"
+  default     = "m5.large.search"
 }
 
 variable "dedicated_master_count" {


### PR DESCRIPTION
As defined in [this ticket](https://github.com/camunda/team-infrastructure-experience/issues/461) the instance type of AWS opensearch examples has been modified from t3.medium search to m7i.large.search

In addition, the default value for the dedicated_master_node of Opensearch clusters has been changed from m4.large.search to m5.large search. The reason for this is that the m5 version is available in all regions, at a consistently cheaper price than the m4 one.