### PR TITLE
Add trivy terraform configuration scan to GH actions lint workflow, and pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
     pull_request:
     push:
-        branches: [main, tfsec-testing]
+        branches: [main]
 
 jobs:
     lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
     pull_request:
     push:
-        branches: [main]
+        branches: [main, tfsec-testing]
 
 jobs:
     lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,3 +11,11 @@ jobs:
     lint:
         uses: camunda/infraex-common-config/.github/workflows/lint-global.yml@08c796604f9b08614df763b333833dd1bdc037c0 # 1.2.11
         secrets: inherit
+
+    trivy:
+        name: Trivy Terraform Vulnerability Scanning
+        uses: aquasecurity/trivy-action/.github/workflows/trivy.yaml@0.29.0
+        with:
+            hide-progress: true
+            scan-type: config
+            trivy-config: .lint/trivy/trivy.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Trivy Scan
-              uses: aquasecurity/trivy-action@v0.29.0
+              uses: aquasecurity/trivy-action@0.29.0
               with:
                   hide-progress: true
                   scan-type: config

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,14 @@ jobs:
 
     trivy:
         name: Trivy Terraform Vulnerability Scanning
-        uses: aquasecurity/trivy-action/.github/workflows/trivy.yaml@0.29.0
-        with:
-            hide-progress: true
-            scan-type: config
-            trivy-config: .lint/trivy/trivy.yaml
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Trivy Scan
+              uses: aquasecurity/trivy-action@v0.29.0
+              with:
+                  hide-progress: true
+                  scan-type: config
+                  trivy-config: .lint/trivy/trivy.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ terraform.tfstate
 terraform.tfstate.backup
 .terraform
 .terraform.lock.hcl
+trivyreport.txt

--- a/.lint/trivy/trivy-scan.sh
+++ b/.lint/trivy/trivy-scan.sh
@@ -1,0 +1,3 @@
+# Since Trivy does not have a pre-commit hook by default, this is a custom hook script
+#!/bin/bash
+trivy config --config .lint/trivy/trivy.yaml --ignorefile .trivyignore

--- a/.lint/trivy/trivy-scan.sh
+++ b/.lint/trivy/trivy-scan.sh
@@ -1,3 +1,2 @@
-# Since Trivy does not have a pre-commit hook by default, this is a custom hook script
 #!/bin/bash
-trivy config --config .lint/trivy/trivy.yaml --ignorefile .trivyignore
+trivy config --config .lint/trivy/trivy.yaml --ignorefile .trivyignore .

--- a/.lint/trivy/trivy.yaml
+++ b/.lint/trivy/trivy.yaml
@@ -1,0 +1,9 @@
+---
+quiet: false
+debug: false
+format: table
+exit-code: 1
+
+misconfiguration:
+    scanners:
+        - terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,4 +78,5 @@ repos:
             name: Trivy Scan
             entry: .lint/trivy/trivy-scan.sh
             language: script
-            types: [yaml, terraform]
+            types: [terraform]
+            working_dir: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,11 @@ repos:
       rev: 0.2.3
       hooks:
           - id: yamlfmt
+
+    - repo: local
+      hooks:
+          - id: trivy-scan
+            name: Trivy Scan
+            entry: .lint/trivy/trivy-scan.sh
+            language: script
+            types: [yaml, terraform]

--- a/.tool-versions
+++ b/.tool-versions
@@ -33,3 +33,5 @@ terraform-docs 0.19.0
 tflint 0.55.0
 
 tfsec 1.28.13
+
+trivy 0.58.1

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,17 +1,10 @@
----
-# HINT: Error Codes are case sensitive. AFAIK you need upper-case on all of them
+AVD-AWS-0040 #(CRITICAL): Public cluster access is enabled.
+AVD-AWS-0041 #(CRITICAL): Cluster allows access from a public CIDR: 0.0.0.0/0
+AVD-AWS-0104 #(CRITICAL): Security group rule allows egress to multiple public internet addresses.
 
-# Ensure deletion protection is enabled for RDS clusters.
-# See https://avd.aquasec.com/misconfig/avd-aws-0343
-# MEDIUM
-# Attention: It is somehow not possible to ignore this error inline. Trivy will fail with an unlocated error (error without locatable origin)
-AVD-AWS-0343
+AVD-AWS-0343 #(MEDIUM): Cluster does not have Deletion Protection enabled
+AVD-AWS-0178 #(MEDIUM): VPC does not have VPC Flow Logs enabled.
+AVD-AWS-0038 #(MEDIUM): Control plane scheduler logging is not enabled.
+AVD-AWS-0077 #(MEDIUM): Cluster instance has very low backup retention period.
 
-# Vulnerabilities introduced with trivy 0.57.0
-# They will be addressed in camunda/team-infrastructure#645
-AVD-AWS-0104
-AVD-AWS-0017
-
-# Disable checks for public cluster access
-AVD-AWS-0040
-AVD-AWS-0041
+AVD-AWS-0133 #(LOW): Instance does not have performance insights enabled.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+---
+# HINT: Error Codes are case sensitive. AFAIK you need upper-case on all of them
+
+# Ensure deletion protection is enabled for RDS clusters.
+# See https://avd.aquasec.com/misconfig/avd-aws-0343
+# MEDIUM
+# Attention: It is somehow not possible to ignore this error inline. Trivy will fail with an unlocated error (error without locatable origin)
+- AVD-AWS-0343
+
+# Vulnerabilities introduced with trivy 0.57.0
+# They will be addressed in camunda/team-infrastructure#645
+- AVD-AWS-0104
+- AVD-AWS-0017

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,9 +5,13 @@
 # See https://avd.aquasec.com/misconfig/avd-aws-0343
 # MEDIUM
 # Attention: It is somehow not possible to ignore this error inline. Trivy will fail with an unlocated error (error without locatable origin)
-- AVD-AWS-0343
+AVD-AWS-0343
 
 # Vulnerabilities introduced with trivy 0.57.0
 # They will be addressed in camunda/team-infrastructure#645
-- AVD-AWS-0104
-- AVD-AWS-0017
+AVD-AWS-0104
+AVD-AWS-0017
+
+# Disable checks for public cluster access
+AVD-AWS-0040
+AVD-AWS-0041

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Terraform module which creates AWS EKS (Kubernetes) resources with an opinionated configuration targeting Camunda 8, an AWS Aurora RDS cluster and an OpenSearch domain.
 
-**⚠️ Warning:** This project is not intended for production use but rather for demonstration purposes only. There are no guarantees or warranties provided.
+**⚠️ Warning:** This project is not intended for production use but rather for demonstration purposes only. There are no guarantees or warranties provided. As such certain Terraform configuration warnings from Trivy have deliberately been ignored. For more details, see the [.trivyignore](./.trivyignore) file in the repository root.
 
 ## Documentation
 


### PR DESCRIPTION
Source issue: https://github.com/camunda/team-infrastructure-experience/issues/37

Trivy terraform configuration checks (formerly tfsec) have been implemented in the repository both as an actions workflow and a pre-commit check. 
