### PR TITLE
chore: update asdf installation action

### DIFF
--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -37,10 +37,8 @@ jobs:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
-            - name: Install tooling using asdf
-              uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-              with:
-                  asdf_branch: v0.15.0
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@d97ec3138367714e8ecf8d925c0b5287450b6b47 # 1.2.17
 
             - name: Use repo .tool-version as global version
               run: cp .tool-versions ~/.tool-versions

--- a/.github/workflows/test-gha-eks.yml
+++ b/.github/workflows/test-gha-eks.yml
@@ -77,10 +77,8 @@ jobs:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
-            - name: Install tooling using asdf
-              uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-              with:
-                  asdf_branch: v0.15.0
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@d97ec3138367714e8ecf8d925c0b5287450b6b47 # 1.2.17
 
             - name: Get Cluster Info
               id: commit_info

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,10 +111,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-            - name: Install tooling using asdf
-              uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-              with:
-                  asdf_branch: v0.15.0
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@d97ec3138367714e8ecf8d925c0b5287450b6b47 # 1.2.17
 
             - name: Import Secrets
               id: secrets
@@ -205,10 +203,8 @@ jobs:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
-            - name: Install tooling using asdf
-              uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-              with:
-                  asdf_branch: v0.15.0
+            - name: Install asdf tools with cache
+              uses: camunda/infraex-common-config/./.github/actions/asdf-install-tooling@d97ec3138367714e8ecf8d925c0b5287450b6b47 # 1.2.17
 
             - name: Import Secrets
               id: secrets


### PR DESCRIPTION
Deprecating usage of the asdf action in favor of an internal one with cache strategy embedded 