### PR TITLE
chore: move vpc id to beginning and sleep

### DIFF
--- a/.github/actions/eks-cleanup-resources/scripts/destroy.sh
+++ b/.github/actions/eks-cleanup-resources/scripts/destroy.sh
@@ -138,13 +138,14 @@ destroy_resource() {
   if [ "$terraform_module" == "eks-cluster" ]; then
     terraform state rm "kubernetes_storage_class_v1.ebs_sc" || true
 
+    VPC_ID=$(terraform output -raw vpc_id)
+
     if ! terraform destroy -auto-approve \
       -var="region=$AWS_REGION" \
       -var="name=$cluster_name" \
       -var="cluster_service_ipv4_cidr=10.190.0.0/16" \
       -var="cluster_node_ipv4_cidr=10.192.0.0/16"; then
         echo "Error destroying EKS cluster $cluster_name"
-        VPC_ID=$(terraform output -raw vpc_id)
 
         export AWS_PAGER=""
         echo "Checking subnetes for $VPC_ID"

--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -74,6 +74,10 @@ jobs:
                   max-age-hours: ${{ env.MAX_AGE_HOURS }}
                   target: all
 
+            # Sleep for 5 minutes to allow the resources to be deleted
+            - name: Sleep
+              run: sleep 300
+
             # There are cases where the deletion of resources fails due to dependencies.
             - name: Retry delete orphaned resources
               id: retry-delete-orphaned-resources


### PR DESCRIPTION
related to our occasional cleanup issues.
1. See what happens with a 5 min sleep timer, as the NAT Gateways still seem to exist
2. Fix the VPC_ID undefined, would work at least on the first destruction as the outputs should still be present.