### PR TITLE
chore: dont cancle renovate concurrent prs to allow finishing runs

### DIFF
--- a/.github/workflows/test-gha-eks.yml
+++ b/.github/workflows/test-gha-eks.yml
@@ -49,10 +49,12 @@ on:
             - .github/workflows/test-gha-eks.yml
             - .github/actions/*/*.yml
 
-# limit to a single execution per actor of this workflow
+# limit to a single execution per ref of this workflow
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    # in case of renovate we don't cancel the previous run, so it can finish it
+    # otherwise weekly renovate PRs with tf docs updates result in broken clusters
+    cancel-in-progress: ${{ github.actor == 'renovate[bot]' && false || true }}
 
 env:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,9 @@ on:
 # limit to a single execution per ref of this workflow
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+    # in case of renovate we don't cancel the previous run, so it can finish it
+    # otherwise weekly renovate PRs with tf docs updates result in broken clusters
+    cancel-in-progress: ${{ github.actor == 'renovate[bot]' && false || true }}
 
 env:
     # please keep those variables synced with daily-cleanup.yml


### PR DESCRIPTION
related to [slack thread](https://camunda.slack.com/archives/C076N4G1162/p1740276612827929)

otherwise would result on biweekly basis, due to schedule, in broken clusters that the cleanup fails to remove properly.
Renovate runs on the weekend, so we don't really care about the time it takes.