### PR TITLE
chore: prepare for deprecation

### DIFF
--- a/.github/actions/aurora-manage-cluster/action.yml
+++ b/.github/actions/aurora-manage-cluster/action.yml
@@ -105,6 +105,10 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Show deprecation warning
+          shell: bash
+          run: echo "::warning::The action is not maintained anymore through this repository. Please use https://github.com/camunda/camunda-deployment-references
+              instead."
         - name: Use Utility Actions
           id: utility
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet

--- a/.github/actions/eks-cleanup-resources/action.yml
+++ b/.github/actions/eks-cleanup-resources/action.yml
@@ -32,6 +32,10 @@ inputs:
 runs:
     using: composite
     steps:
+        - name: Show deprecation warning
+          shell: bash
+          run: echo "::warning::The action is not maintained anymore through this repository. Please use https://github.com/camunda/camunda-deployment-references
+              instead."
         - name: Delete resources
           id: delete_resources
           shell: bash

--- a/.github/actions/eks-manage-cluster/action.yml
+++ b/.github/actions/eks-manage-cluster/action.yml
@@ -83,6 +83,10 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Show deprecation warning
+          shell: bash
+          run: echo "::warning::The action is not maintained anymore through this repository. Please use https://github.com/camunda/camunda-deployment-references
+              instead."
         - name: Use Utility Actions
           id: utility
           # see https://github.com/orgs/community/discussions/41927 it's not possible to optimize this yet

--- a/.github/actions/opensearch-manage-cluster/action.yml
+++ b/.github/actions/opensearch-manage-cluster/action.yml
@@ -103,6 +103,10 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Show deprecation warning
+          shell: bash
+          run: echo "::warning::The action is not maintained anymore through this repository. Please use https://github.com/camunda/camunda-deployment-references
+              instead."
         - name: Use Utility Actions
           id: utility
           uses: camunda/camunda-tf-eks-module/.github/actions/utility-action@3d6b87546fe8ad01cd0cfd916dcc2326d04bae6c # 3.1.3

--- a/.github/actions/utility-action/action.yml
+++ b/.github/actions/utility-action/action.yml
@@ -68,6 +68,10 @@ outputs:
 runs:
     using: composite
     steps:
+        - name: Show deprecation warning
+          shell: bash
+          run: echo "::warning::The action is not maintained anymore through this repository. Please use https://github.com/camunda/camunda-deployment-references
+              instead."
         - name: Install Terraform
           uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
           with:

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,0 @@
-{
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["github>camunda/infraex-common-config:default.json5"],
-  groupName: "mono-update-renovate", // we keep all updates in a single renovate branch in order to save CI tests
-}

--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -14,9 +14,6 @@ on:
             - .github/workflows/daily-cleanup.yml
             - .github/actions/eks-cleanup-resources/**
 
-    schedule:
-        - cron: 0 1 * * * # At 01:00 everyday.
-
 env:
     MAX_AGE_HOURS: ${{ github.event.inputs.max_age_hours || '20' }}
     AWS_PROFILE: infex

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,6 @@
 name: Pull Request Labeler
 on:
     pull_request_target:
-    schedule:
-        - cron: 0 1 * * 1
     pull_request:
         paths:
             - .github/workflows/labeler.yml

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,8 +4,6 @@ name: Check external links
 on:
     push:
     workflow_dispatch:
-    schedule:
-        - cron: 0 3 1 * *
     pull_request:
         paths:
             - .github/workflows/links.yml

--- a/.github/workflows/test-gha-eks.yml
+++ b/.github/workflows/test-gha-eks.yml
@@ -2,8 +2,6 @@
 name: EKS Cluster with an AuroraDB and OpenSearch creation and destruction test
 
 on:
-    schedule:
-        - cron: 0 1 * * 2 # At 01:00 on Tuesday.
 
     workflow_dispatch:
         inputs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@
 name: Terraform modules tests
 
 on:
-    schedule:
-        - cron: 0 1 * * 2
     workflow_dispatch:
     pull_request:
         # the paths should be synced with ../labeler.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Camunda Terraform EKS Modules
 
+> [!CAUTION]
+> ⚠️ **Repository Not Maintained Anymore**
+> This repository is no longer actively maintained. All related files have been moved to
+> [**camunda-deployment-references**](https://github.com/camunda/camunda-deployment-references).
+>
+> The decision behind this change is to consolidate all reference implementations into a single repository.
+> This makes it easier for us to maintain and for you as a user to find implementations for different cloud providers.
+>
+> We have not archived this repository yet in case backport changes are needed. However, all active maintenance will
+> be done in the new repository.
+>
+> **Important:** Please do not directly consume the Terraform module sources. Instead, maintain your own copy.
+
+
 [![Camunda](https://img.shields.io/badge/Camunda-FC5D0D)](https://www.camunda.com/)
 [![tests](https://github.com/camunda/camunda-tf-eks-module/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/camunda/camunda-tf-eks-module/actions/workflows/tests.yml)
 [![License](https://img.shields.io/github/license/camunda/camunda-tf-eks-module)](LICENSE)


### PR DESCRIPTION
related to https://github.com/camunda/team-infrastructure-experience/issues/433

Contents of this repository are moved to a monorepo for our deployment references.

- Adds warning to action usage
- Removes workflow schedules
    - would leave the other triggers in case we have to backport something
    - I'd leave 8.5 / 8.6 docs as is and refer to newer docs instead to be used
- Adds warning to readme
- removes renovate config
