### PR TITLE
chore: backport webmodeler fix

### DIFF
--- a/examples/camunda-8.6/helm-values/values-domain.yml
+++ b/examples/camunda-8.6/helm-values/values-domain.yml
@@ -95,7 +95,8 @@ webModeler:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/${DB_WEBMODELER_NAME}
             user: ${DB_WEBMODELER_USERNAME}
-            existingSecret: webmodeler-postgres-secret
+            existingSecret:
+                name: webmodeler-postgres-secret
             existingSecretPasswordKey: password
         mail:
             existingSecret: identity-secret-for-components # reference the smtp password

--- a/examples/camunda-8.6/helm-values/values-no-domain.yml
+++ b/examples/camunda-8.6/helm-values/values-no-domain.yml
@@ -79,7 +79,8 @@ webModeler:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/${DB_WEBMODELER_NAME}
             user: ${DB_WEBMODELER_USERNAME}
-            existingSecret: webmodeler-postgres-secret
+            existingSecret:
+                name: webmodeler-postgres-secret
             existingSecretPasswordKey: password
         mail:
             existingSecret: identity-secret-for-components # reference the smtp password

--- a/examples/camunda-8.7/helm-values/values-domain.yml
+++ b/examples/camunda-8.7/helm-values/values-domain.yml
@@ -95,7 +95,8 @@ webModeler:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/${DB_WEBMODELER_NAME}
             user: ${DB_WEBMODELER_USERNAME}
-            existingSecret: webmodeler-postgres-secret
+            existingSecret:
+                name: webmodeler-postgres-secret
             existingSecretPasswordKey: password
         mail:
             existingSecret: identity-secret-for-components # reference the smtp password

--- a/examples/camunda-8.7/helm-values/values-no-domain.yml
+++ b/examples/camunda-8.7/helm-values/values-no-domain.yml
@@ -79,7 +79,8 @@ webModeler:
         externalDatabase:
             url: jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/${DB_WEBMODELER_NAME}
             user: ${DB_WEBMODELER_USERNAME}
-            existingSecret: webmodeler-postgres-secret
+            existingSecret:
+                name: webmodeler-postgres-secret
             existingSecretPasswordKey: password
         mail:
             existingSecret: identity-secret-for-components # reference the smtp password


### PR DESCRIPTION
naming is very confusing at the helm chart, for irsa its working correctly since we dont use the password anyway and just need anything valid to be mounted to not block the k8s reference.

For non irsa version, the existingSecret was always autogenerated instead of using the passed secret.
The Helm chart implementation relies on `existingSecret.name`